### PR TITLE
Fix cookie banner behavior and z-index issue

### DIFF
--- a/common/common.scss
+++ b/common/common.scss
@@ -364,7 +364,7 @@ header.d-header {
   position: fixed;
   bottom: 0;
   left: 0;
-  z-index: 2;
+  z-index: 4;
   width: 100%;
   font-size: 12px;
   background-color: #171b1f;

--- a/common/head_tag.html
+++ b/common/head_tag.html
@@ -3,3 +3,25 @@
 <link href="https://fonts.googleapis.com/css?family=Space+Mono:400,700" rel="stylesheet">
 <link href='https://fonts.googleapis.com/css?family=Open+Sans:300,400,600,700' rel='stylesheet' type='text/css' data-noprefix>
 <script src="https://maxcdn.bootstrapcdn.com/bootstrap/3.2.0/js/bootstrap.min.js" integrity="sha384-Tc5IQib027qvyjSMfHjOMaLkfuWVxZxUPnCJA7l2mCWNIpG9mGCD8wGNIcPD7Txa" crossorigin="anonymous"></script>
+<script type="text/discourse-plugin" version="0.1">
+  api.onPageChange((url) => {
+    const cookieBanner = document.querySelector('.cookie-banner');
+    const cookieBannerOk = document.querySelector('.cookie-banner__btn--ok');
+    const setReadCookiePolicy = () => {
+      document.cookie = `_inv_read_cookie_policy_at=${(new Date).getTime()}; Domain=inventables.com`;
+    };
+    const didReadCookiePolicy = () => {
+      return document.cookie.split(';').some(crumb => crumb.trim().startsWith('_inv_read_cookie_policy_at='));
+    };
+    cookieBannerOk.addEventListener('click', () => {
+      cookieBanner.style.display = 'none';
+    });
+    if (!didReadCookiePolicy()) {
+      setReadCookiePolicy();
+      cookieBanner.style.display = 'block';
+    }
+    else {
+      cookieBanner.style.display = 'none';
+    }
+  });
+</script>

--- a/common/header.html
+++ b/common/header.html
@@ -141,7 +141,6 @@
         
     });
 </script>
-<!--
 <section class="cookie-banner" style="display: none;">
   <p class="cookie-banner-title"><strong>This website uses cookies</strong></p>
   <p>We use cookies to personalize content, interact with our analytics companies, advertising networks and cooperatives, and demographic companies, provide social media features, and to analyze our traffic. Our social media, advertising and analytics partners may combine it with other information that you’ve provided to them or that they’ve collected from your use of their services. <a href='https://www.inventables.com/policies/privacy-policy' target='_blank'>Learn more.</a></p>
@@ -150,24 +149,3 @@
     <button class="cookie-banner__btn--ok">OK</button>
   </div>
 </section>
-
-<script>
-  document.addEventListener('DOMContentLoaded', () => {
-    const cookieBanner = document.querySelector('.cookie-banner');
-    const cookieBannerOk = document.querySelector('.cookie-banner__btn--ok');
-    const setReadCookiePolicy = () => {
-      document.cookie = `_inv_read_cookie_policy_at=${(new Date).getTime()}; Domain=inventables.com`;
-    };
-    const didReadCookiePolicy = () => {
-      return document.cookie.split(';').some(crumb => crumb.trim().startsWith('_inv_read_cookie_policy_at='));
-    };
-    cookieBannerOk.addEventListener('click', () => {
-      cookieBanner.style.display = 'none';
-    });
-    if (!didReadCookiePolicy()) {
-      setReadCookiePolicy();
-      cookieBanner.style.display = 'block';
-    }
-  });
-</script>
--->


### PR DESCRIPTION
- Moves the script into `head-tag.html`
- Adds `text/discourse-plugin` type attribute
- Modifies the script to hook into `api.onPageChange` instead of the `DOMContentLoaded` event.
- Updates the z-index for the banner to put it above the user avatars and "last visit" line.

Since Discourse is a single page app and the banner was loaded in the header it was not closing on page changes. 

![Screen Shot 2023-08-31 at 9 47 18 AM](https://github.com/inventables/forum-theme/assets/4523710/ecbe8414-2e23-42f7-b857-b25abb32b0e1)

Resolves https://github.com/inventables/fbolt/issues/6404

