### PR TITLE
Fix propagation of cookie banner between pages

### DIFF
--- a/common/head_tag.html
+++ b/common/head_tag.html
@@ -8,7 +8,7 @@
     const cookieBanner = document.querySelector('.cookie-banner');
     const cookieBannerOk = document.querySelector('.cookie-banner__btn--ok');
     const setReadCookiePolicy = () => {
-      document.cookie = `_inv_read_cookie_policy_at=${(new Date).getTime()}; Domain=inventables.com`;
+      document.cookie = `_inv_read_cookie_policy_at=${(new Date).getTime()}; domain=inventables.com; path=/; max-age=31536000`;
     };
     const didReadCookiePolicy = () => {
       return document.cookie.split(';').some(crumb => crumb.trim().startsWith('_inv_read_cookie_policy_at='));


### PR DESCRIPTION
This applies the change from https://github.com/inventables/easel/pull/10069 to set the cookie banner cookie's `path` to allow it to be read from any paths on our domain—by default cookies are scoped to the beginning part of the path of the page where they're set (e.g. `/products` when set from a product page). Also sets `max-age` to 365 days so that the cookie outlasts the session.