### PR TITLE
Make cookie banner more clickable on mobile

### DIFF
--- a/common/common.scss
+++ b/common/common.scss
@@ -364,8 +364,8 @@ header.d-header {
   position: fixed;
   bottom: 0;
   left: 0;
-  z-index: 4;
-  width: 100%;
+  z-index: 101;
+  width: 80%;
   font-size: 12px;
   background-color: #171b1f;
   padding: 0 20px 20px 20px;


### PR DESCRIPTION
Closes https://github.com/inventables/easel/issues/11525

Before
![Screenshot 2024-09-17 at 4 55 55 PM](https://github.com/user-attachments/assets/63fca58f-0498-49f1-801d-a9f6c3ffeec8)
After
![Screenshot 2024-09-17 at 4 56 08 PM](https://github.com/user-attachments/assets/49a75db8-fa80-47b1-8ba3-2dfe9addd034)



Makes cookie banner be above the topic z-index (100) and makes it slightly smaller in width so it doesn't get truncated.