### PR TITLE
change the category description css so subcategories render more nicely

### DIFF
--- a/common/common.scss
+++ b/common/common.scss
@@ -414,3 +414,7 @@ header.d-header {
 .cookie-banner__btn--ok:hover {
   cursor: pointer;
 }
+
+.categories-list .category .category-description {
+  overflow: auto;
+}


### PR DESCRIPTION
^^
Tested by adding the style in console.
Before:
<img width="569" alt="Screenshot 2024-09-26 at 10 22 26 AM" src="https://github.com/user-attachments/assets/a84a0a8a-59bb-431a-a24b-36179407e0a0">


After:
<img width="578" alt="Screenshot 2024-09-26 at 10 22 17 AM" src="https://github.com/user-attachments/assets/bedd6fcc-f950-43c0-a155-55791816cc28">
